### PR TITLE
Pass-through kwargs to translate method.

### DIFF
--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -175,7 +175,7 @@ class SeqLike:
         else:
             return swap_representation(self)
 
-    def aa(self, auto_translate=True) -> "SeqLike":
+    def aa(self, auto_translate=True, **kwargs) -> "SeqLike":
         """
         Return the amino acid view of the SeqLike object.
 
@@ -185,17 +185,19 @@ class SeqLike:
         :param auto_translate: Whether to automagically translate
             an NT sequence into an AA sequence.
             Defaults to True.
+        :param kwargs: These kwargs are passed into
+            BioPython SeqRecord's `.translate()` method.
+            They can be used to set SeqRecord properties.
         :returns: copy of self with sequence object as amino acid sequence.
         """
         # Start with auto-translation
         if self._nt_record and self._aa_record is None and auto_translate:
-            return self.translate()
+            return self.translate(**kwargs)
 
         # Return based on _type.
         if self._type == "AA":
             return deepcopy(self)
-        else:
-            return swap_representation(self)
+        return swap_representation(self)
 
     # ------------------------- Methods to inter-convert Sequence to various Biopython formats -------------------------
     # Function to convert input sequence to a string


### PR DESCRIPTION
This allows us to call `.aa(id=True, name=True, description=True)`. The kwargs will be passed through to `.translate()`, which will in turn pass through to Seq's `.translate()`.