### PR TITLE
Ensure that translate() generates correct seqnums letter_annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Ensure that `.translate()` generates a SeqLike with "seqnum" letter annotations (@ndousis)
+
 ## [v1.1.3] - 2021-11-03
 
 -   First public release of SeqLike h/t @andrewgiessel @maxasauruswall @MihirMetkar @ndousis @ericmjl @dtjohnson @JDFontenot

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -318,7 +318,7 @@ class SeqLike:
                 "As a safeguard, SeqLike objects do not allow this to happen. "
             )
         sc._nt_record.annotations["molecule_type"] = "DNA"
-        sc._aa_record = sc._nt_record.translate(gap=gap_letter, **kwargs)
+        sc._aa_record = record_from(sc._nt_record.translate(gap=gap_letter, **kwargs))
         return sc.aa()
 
     def back_translate(self, codon_map: Callable = None, **kwargs) -> "SeqLike":

--- a/tests/test_SeqLike.py
+++ b/tests/test_SeqLike.py
@@ -139,12 +139,13 @@ def test_SeqLike_interconversion():
     e2 = SeqLike(d2, "aa", alphabet=seq2.alphabet).to_str()
     assert e1 == a1
     assert e2 == a2
-    # when interconverting, should the letter_annotations be empty?
-    assert seq2.letter_annotations == {}
+    # when interconverting, regenerate the letter_annotations as if starting from scratch
+    seqnums2 = [str(i + 1) for i in range(len(seq2))]
+    assert seq2.letter_annotations == SeqLike(seq2, "aa").letter_annotations == {"seqnums": seqnums2}
     seq3 = SeqLike(seq2, "dna")
-    seqnums = [str(i + 1) for i in range(len(seq3))]
-    assert seq3.letter_annotations["seqnums"] == seqnums
-    assert seq3[:2].letter_annotations["seqnums"] == seqnums[:2]
+    seqnums3 = [str(i + 1) for i in range(len(seq3))]
+    assert seq3.letter_annotations == SeqLike(seq3, "nt").letter_annotations == {"seqnums": seqnums3}
+    assert seq3[:2].letter_annotations["seqnums"] == seqnums3[:2]
 
 
 CODON_TABLES = {"ecoli_k12": yeast_codon_table, "Kazusa_yeast": yeast_codon_table}


### PR DESCRIPTION
`SeqLike.translate()` now yields a SeqLike as if initialized from scratch (i.e., `letter_annotations["seqnums"]` is populated).  Updated the tests, all tests pass.

Closes #20 