### PR TITLE
Simplify .aa() interface, return original SeqRecord attributes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,14 +28,18 @@ jobs:
             seqlike-dev.tar.gz
           key: ${{ runner.os }}-env.${{ hashFiles('environment.yml') }}
 
+      - name: Install mamba
+        if: steps.cache-environment.outputs.cache-hit != 'true'
+        run: conda install -c conda-forge mamba
+
       - name: Build environment
         if: steps.cache-environment.outputs.cache-hit != 'true'
         run: |
-          conda env create -f environment.yml
+          mamba env update -f environment.yml
 
       - name: Install conda-pack
         if: steps.cache-environment.outputs.cache-hit != 'true'
-        run: conda install -c conda-forge conda-pack
+        run: mamba install -c conda-forge conda-pack
 
       - name: Run conda-pack
         if: steps.cache-environment.outputs.cache-hit != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Simplify `.aa()` interface, return original SeqRecord attributes (@ndousis)
+
 ## [v1.1.5] - 2021-11-15
 
 -   Ensure that `python-codon-tables` is listed as an explicit dependency in `setup.py` (@ericmjl)

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,8 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python>=3.9
+  - python<=3.9 # 18 Nov 2021: A super esoteric issue leads to us pinning env at 3.9.
+  # For more information, see: https://github.com/conda/conda-pack/issues/196#issuecomment-971790933
   - pip
   - scikit-learn
   - biopython
@@ -33,5 +34,10 @@ dependencies:
   - mkdocstrings
   # Infrastructural
   - bump2version
+  # Dependencies of mknotebooks
+  - gitpython
+  - jupyter
+  - markdown
+  - nbconvert
   - pip:
       - mknotebooks # for notebooks in docs

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - matplotlib
   - bokeh
   - python-codon-tables
+  - mkdocstrings
   # Code quality
   - pre-commit
   - darglint
@@ -31,5 +32,4 @@ dependencies:
   # Infrastructural
   - bump2version
   - pip:
-      - mkdocstrings # for docstrings
-      - mknotebooks  # for notebooks in docs
+      - mknotebooks # for notebooks in docs

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -177,7 +177,7 @@ class SeqLike:
         else:
             return swap_representation(self)
 
-    def aa(self, auto_translate=True, **kwargs) -> "SeqLike":
+    def aa(self, auto_translate=True) -> "SeqLike":
         """
         Return the amino acid view of the SeqLike object.
 
@@ -187,14 +187,12 @@ class SeqLike:
         :param auto_translate: Whether to automagically translate
             an NT sequence into an AA sequence.
             Defaults to True.
-        :param kwargs: These kwargs are passed into
-            BioPython SeqRecord's `.translate()` method.
-            They can be used to set SeqRecord properties.
         :returns: copy of self with sequence object as amino acid sequence.
         """
         # Start with auto-translation
         if self._nt_record and self._aa_record is None and auto_translate:
-            return self.translate(**kwargs)
+            return self.translate(id=True, name=True, description=True,
+                                  annotations=True, dbxrefs=True)
 
         # Return based on _type.
         if self._type == "AA":

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -177,22 +177,41 @@ class SeqLike:
         else:
             return swap_representation(self)
 
-    def aa(self, auto_translate=True) -> "SeqLike":
+    def aa(self, auto_translate=True, **kwargs) -> "SeqLike":
         """
         Return the amino acid view of the SeqLike object.
 
         The method will automagically translate the `._nt_record`
         of its SeqLike object if the `._aa_record` does not exist.
 
+        We preserve all NT record attributes for convenience in sequence manipulation
+        tasks where the starter sequence is an NT and we merely want the AA form.
+        The default behaviour, thus, has `id=True`, `name=True`, `description=True`,
+        `annotations=True`, and `dbxrefs=True`.
+        
+        To change the behaviour, you can set any of those to False in `.aa()`, for example:
+        ```
+            seq.aa(id=False)
+        ```
+
         :param auto_translate: Whether to automagically translate
             an NT sequence into an AA sequence.
             Defaults to True.
+        :param kwargs: These kwargs are passed into BioPython SeqRecord's
+            `.translate()` method.  The default behaviour is set to `id=True`,
+            `name=True`, `description=True`, `annotations=True`, and `dbxrefs=True`.
         :returns: copy of self with sequence object as amino acid sequence.
         """
         # Start with auto-translation
         if self._nt_record and self._aa_record is None and auto_translate:
-            return self.translate(id=True, name=True, description=True,
-                                  annotations=True, dbxrefs=True)
+            translate_kwargs = dict(
+                id=True, name=True, 
+                description=True,
+                annotations=True,
+                dbxrefs=True
+            )
+            translate_kwargs.update(kwargs)
+            return self.translate(**translate_kwargs)
 
         # Return based on _type.
         if self._type == "AA":

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -188,10 +188,12 @@ class SeqLike:
         tasks where the starter sequence is an NT and we merely want the AA form.
         The default behaviour, thus, has `id=True`, `name=True`, `description=True`,
         `annotations=True`, and `dbxrefs=True`.
-        
-        To change the behaviour, you can set any of those to False in `.aa()`, for example:
-        ```
-            seq.aa(id=False)
+
+        To change the behaviour,
+        you can set any of those to False in `.aa()`, for example:
+
+        ```python
+        seq.aa(id=False)
         ```
 
         :param auto_translate: Whether to automagically translate
@@ -204,12 +206,7 @@ class SeqLike:
         """
         # Start with auto-translation
         if self._nt_record and self._aa_record is None and auto_translate:
-            translate_kwargs = dict(
-                id=True, name=True, 
-                description=True,
-                annotations=True,
-                dbxrefs=True
-            )
+            translate_kwargs = dict(id=True, name=True, description=True, annotations=True, dbxrefs=True)
             translate_kwargs.update(kwargs)
             return self.translate(**translate_kwargs)
 


### PR DESCRIPTION
Removed **kwargs from SeqLike `aa`, and hard-coded arguments in the call to `self.translate` so as to return original attributes like `id` and `name`.  This is the behavior I would expect from `aa()`.

I left the interface to SeqLike `translate` as is to maintain flexibility.

Closes #25 