### PR TITLE
[DOC] Correct inaccuracy in SeqLike documentation

### DIFF
--- a/docs/development/seqlike-object.md
+++ b/docs/development/seqlike-object.md
@@ -3,7 +3,8 @@
 ## Purpose of this document
 
 The purpose of this document is to accurately document the SeqLike object's intended behaviour.
-It is not a replacement for docstrings, which serve as a reference for the arguments of the SeqLike methods.
+It is not a replacement for docstrings,
+which serve as a reference for the arguments of the SeqLike methods.
 
 You should read this document if:
 
@@ -13,7 +14,6 @@ You should read this document if:
 What is explicitly out-of-scope for this document are:
 
 1. Places that we need help (please consult code for TODOs)
-2.
 
 ## SeqLike Object Overview
 
@@ -74,14 +74,23 @@ that accepts and returns an AA SeqLike object.
 
 ## How the constructor works
 
-Inside the constructor,
+The `seqlike` package provides the `SeqLike` class,
+which is used for constructing SeqLike objects.
+In the constructor, the `seq_type` argument is required
+in order to avoid incorrectly inferring whether a sequence
+is a nucleotide or amino acid sequence.
+For convenience, there are also `aaSeqLike` and `ntSeqLike` factory functions
+that return a SeqLike constructed with the appropriate `seq_type` specified.
+Inside the SeqLike object's constructor,
 we use a dispatching pattern that returns a tuple of attributes
 based on the Python object types that are passed in.
 This design choice is highly inspired by the dispatching pattern
 prevalent in the Julia language,
 which makes reasoning about the behaviour of the constructor much easier.
-It also makes the code flatter and easier to read. (Zen of Python, friends!)
-The main function that determines SeqLike attribute values is called `_construct_seqlike`.
+It also makes the code flatter and easier to read.
+(Zen of Python, friends!)
+The main function that determines SeqLike attribute values
+is called `_construct_seqlike`.
 At a high level, this is what happens inside `_construct_seqlike`:
 
 1. We determine the `_type` and `alphabet` of the sequence based on the passed-in `seq_type`, `alphabet`, and `sequence` arguments.
@@ -191,8 +200,8 @@ And so on and so-forth.
 All of this is handled by dispatching on a single function `record_from`.
 (If you're not familiar with what dispatching is,
 this is inspired from the Julia language.
-We use the `plum` library to handle dispatching,
-check out its repository [here](https://github.com/wesselb/plum)
+We use the `multipledispatch` library to handle dispatching,
+check out its repository [here](https://github.com/mrocklin/multipledispatch)
 to read more about it.)
 
 By using dispatching, we ensure that whatever data type is passed in for `sequence`

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -72,16 +72,17 @@ class SeqLike:
     Here's a quick usage example:
 
     ```python
+    from seqlike import SeqLike
     example = 'ATCGATC'
 
-    seq_record = SeqLike(example).to_seqrecord()
-    seq = SeqLike(example).to_seq()
-    seq_str = SeqLike(example).to_str()
-    seq_index = SeqLike(example).to_index()
-    seq_onehot = SeqLike(example).to_onehot()
+    seq_record = SeqLike(example, seq_type="nt").to_seqrecord()
+    seq = SeqLike(example, seq_type="nt").to_seq()
+    seq_str = SeqLike(example, seq_type="nt").to_str()
+    seq_index = SeqLike(example, seq_type="nt").to_index()
+    seq_onehot = SeqLike(example, seq_type="nt").to_onehot()
     ```
 
-    Any of theose representations can be generated or passed in as an input.
+    Any of the aformentioned representations can be generated or passed in as an input.
     If using onehot or index encodings, they are of the shape:
     (N x NUM_BASES) and (N), respectively.
     We use symbols from our extended nucleotide and protein alphabets.
@@ -103,10 +104,6 @@ class SeqLike:
     The constructor also takes optional keyword arguments
     that are passed on to SeqRecord.
     For the id attribute, if unspecified we generate a random hexadecimal UUID.
-    The optional seq_type argument is one of 'DNA', 'RNA', 'NT', or 'AA'.
-    If seq_type is None, we try to infer this with the following simple rule:
-    if the sequence is entirely made of -ACGTUN, we assume it's an NT,
-    otherwise we use an AA.
 
     `codon_map` defines back-translation from an AA sequence to a NT sequence.
     This is formatted as a callable, see `codon_tables.py` for more info.


### PR DESCRIPTION
This PR corrects inaccuracies in SeqLike's class docstrings and SeqLike object reference documentation.

h/t @pagpires for the note in #41. I'd love to get feedback on whether the docs read better now.

Closes #41.