### PR TITLE
[ENH] Speed up import time of SeqLike

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.1.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/kynan/nbstripout

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/docs/development/import-speed.md
+++ b/docs/development/import-speed.md
@@ -1,0 +1,62 @@
+# Optimizing for Import Speed
+
+As SeqLike forms the basis of downstream tooling,
+import timing becomes important as well.
+As such, we have implemented a few tricks to enable fast importing of the library.
+
+## Lazy Loading
+
+In accordance with [SPEC-001][spec],
+we use `lazy_loader` to lazily load Python packages into our modules.
+Doing so ensures that we do not incur the time penalty
+associated with importing large packages, such as:
+
+- pandas
+- NumPy
+- matplotlib
+- bokeh
+
+[spec]: https://scientific-python.org/specs/spec-0001/
+
+The general pattern we use here is to do:
+
+```python
+import lazy_loader as lazy
+
+pd = lazy.load("pandas") # equivalent to `import pandas as pd`
+```
+
+This pattern is generally useful only for top-level packages.
+
+## Nesting imports
+
+The second strategy for deferring imports
+is to import them within functions and class methods.
+We do this when there are submodules
+or specific functions/classes that we need to access.
+One example is Bokeh:
+
+```python
+def some_bokeh_function():
+    from bokeh.plotting import figure
+    ...
+    p1 = figure(...)
+```
+
+## Try/Excepts
+
+The third pattern we use is the try/except pattern.
+This one is particularly useful
+for distinguishing between notebook and shell environments.
+For example, in `draw_utils.py`, we use the following pattern:
+
+```python
+try:
+    get_ipython
+    from bokeh.io import output_notebook
+
+    output_notebook()
+```
+
+This way, we avoid executing `output_notebook()`
+if we are in a CLI/shell environment and not in a Jupyter notebook environment.

--- a/docs/notebooks/tutorial.ipynb
+++ b/docs/notebooks/tutorial.ipynb
@@ -704,7 +704,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -43,3 +43,4 @@ dependencies:
   - pip:
       - mknotebooks # for notebooks in docs
       - build
+      - lazy-loader

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -2,15 +2,15 @@ from inspect import Attribute
 import itertools
 
 from warnings import warn
-from .utils.validation import validate_seq_type
 
 import uuid
 import warnings
 from copy import deepcopy
 from functools import reduce
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
-import numpy as np
+import lazy_loader as lazy
+
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from multipledispatch import dispatch
@@ -34,6 +34,9 @@ from .utils import (
     add_seqnums_to_letter_annotations,
     ungap,
 )
+
+np = lazy.load("numpy")
+
 
 # TODO: Do we want to do some arithmetic on types here?
 ArrayType = Union[

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -4,7 +4,6 @@ import itertools
 from warnings import warn
 from .utils.validation import validate_seq_type
 
-# from seqlike.utils.constructor import get_encoders
 import uuid
 import warnings
 from copy import deepcopy
@@ -28,7 +27,6 @@ from .alphabets import (
     is_STANDARD_NT,
 )
 from .encoders import (
-    ENCODERS,
     index_encoder_from_alphabet,
     onehot_encoder_from_alphabet,
 )
@@ -38,7 +36,10 @@ from .utils import (
 )
 
 # TODO: Do we want to do some arithmetic on types here?
-ArrayType = Union[list, np.ndarray,]
+ArrayType = Union[
+    list,
+    np.ndarray,
+]
 StringLikeType = Union[str, Seq, SeqRecord]
 SeqLikeType = Union[ArrayType, StringLikeType, "SeqLike"]
 
@@ -889,7 +890,7 @@ def _construct_seqlike(sequence, seq_type, alphabet, codon_map, **kwargs) -> tup
 
 
 @dispatch(
-    ArrayType.__args__ + StringLikeType.__args__, # TODO: Figure out a way to include torch tensors w/o requiring torch
+    ArrayType.__args__ + StringLikeType.__args__,  # TODO: Figure out a way to include torch tensors w/o requiring torch
     (str),
     (str, type(None)),
     (object, type(None)),
@@ -1066,7 +1067,7 @@ def swap_representation(s: SeqLike) -> SeqLike:
     return sc
 
 
-@dispatch(str, type(None), StringLikeType.__args__+ArrayType.__args__)
+@dispatch(str, type(None), StringLikeType.__args__ + ArrayType.__args__)
 def determine__type_and_alphabet(seq_type, alphabet, sequence):
     """Determine _type and alphabet when _type is set and alphabet is None.
 
@@ -1078,7 +1079,7 @@ def determine__type_and_alphabet(seq_type, alphabet, sequence):
     return _type, alphabet
 
 
-@dispatch(str, str, StringLikeType.__args__+ArrayType.__args__)
+@dispatch(str, str, StringLikeType.__args__ + ArrayType.__args__)
 def determine__type_and_alphabet(seq_type, alphabet, sequence):
     """Determine _type and alphabet when _type is set and alphabet is set.
 
@@ -1105,7 +1106,7 @@ def determine__type(alphabet, sequence) -> str:
         return "NT"
 
 
-@dispatch(str, StringLikeType.__args__+(SeqLike,))
+@dispatch(str, StringLikeType.__args__ + (SeqLike,))
 def determine_alphabet(_type, sequence) -> str:
     """Determine alphabet from _type and sequence.
 

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -41,7 +41,7 @@ np = lazy.load("numpy")
 # TODO: Do we want to do some arithmetic on types here?
 ArrayType = Union[
     list,
-    "np.ndarray",
+    np.ndarray,
 ]
 StringLikeType = Union[str, Seq, SeqRecord]
 SeqLikeType = Union[ArrayType, StringLikeType, "SeqLike"]

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -41,7 +41,7 @@ np = lazy.load("numpy")
 # TODO: Do we want to do some arithmetic on types here?
 ArrayType = Union[
     list,
-    np.ndarray,
+    "np.ndarray",
 ]
 StringLikeType = Union[str, Seq, SeqRecord]
 SeqLikeType = Union[ArrayType, StringLikeType, "SeqLike"]

--- a/seqlike/SeqLikeAccessor.py
+++ b/seqlike/SeqLikeAccessor.py
@@ -131,7 +131,7 @@ class SeqLikeAccessor:
         seqnum_labels=None,
         ref_id=None,
         cols=50,
-        color_scheme=aa_chemistry_simple(),
+        color_scheme=aa_chemistry_simple,
         logo_font="ArialMT",
         logo_format="png",
         resolution=200,

--- a/seqlike/SeqLikeAccessor.py
+++ b/seqlike/SeqLikeAccessor.py
@@ -8,8 +8,7 @@ from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.Data.IUPACData import extended_protein_values
 from PIL import Image
-from weblogo import LogoData, LogoFormat, LogoOptions, formatters
-from weblogo.seq import Alphabet
+
 
 from .alignment_utils import align
 from .alphabets import (
@@ -114,9 +113,9 @@ class SeqLikeAccessor:
         :returns: a PIL Image object or Bokeh object.
         """
         if colorscheme is None and self._type == "NT":
-            colorscheme = nt_simple
+            colorscheme = nt_simple()
         elif colorscheme is None and self._type == "AA":
-            colorscheme = aa_chemistry_simple
+            colorscheme = aa_chemistry_simple()
 
         if use_bokeh:
             try:
@@ -132,7 +131,7 @@ class SeqLikeAccessor:
         seqnum_labels=None,
         ref_id=None,
         cols=50,
-        color_scheme=aa_chemistry_simple,
+        color_scheme=aa_chemistry_simple(),
         logo_font="ArialMT",
         logo_format="png",
         resolution=200,
@@ -149,6 +148,7 @@ class SeqLikeAccessor:
         :param **kwargs: additional weblogo arguments
         :returns: PIL Image object
         """
+        import weblogo as wl
 
         def highlight_consensus(labels, consensus, ref):
             new_labels = list()
@@ -172,8 +172,8 @@ class SeqLikeAccessor:
             seqnum_labels = range(1, len(consensus) + 1)
 
         # set weblogo options
-        opts = LogoOptions(
-            formatter=formatters[logo_format],
+        opts = wl.LogoOptions(
+            formatter=wl.formatters[logo_format],
             stacks_per_line=cols,
             color_scheme=color_scheme,
             logo_font=logo_font,
@@ -185,14 +185,14 @@ class SeqLikeAccessor:
 
         # remove gap and stop characters so that they are not included in weblogo
         ignore = [gap_letter, stop_letter]
-        alphabet = Alphabet([s for s in self.alphabet if s not in ignore])
+        alphabet = wl.seq.Alphabet([s for s in self.alphabet if s not in ignore])
         counts = [count for s, count in self.as_counts_by_alphabet() if s not in ignore]
 
         # count position-specific frequencies
-        data = LogoData.from_counts(alphabet, np.array(counts).T)
+        data = wl.LogoData.from_counts(alphabet, np.array(counts).T)
 
         # return logo as png image
-        logo = opts.formatter(data, LogoFormat(data, opts))
+        logo = opts.formatter(data, wl.LogoFormat(data, opts))
         return Image.open(io.BytesIO(logo))
 
     def align(self, preserve_order: bool = True, *args, **kwargs):

--- a/seqlike/SeqLikeAccessor.py
+++ b/seqlike/SeqLikeAccessor.py
@@ -179,7 +179,7 @@ class SeqLikeAccessor:
         opts = wl.LogoOptions(
             formatter=wl.formatters[logo_format],
             stacks_per_line=cols,
-            color_scheme=color_scheme,
+            color_scheme=color_scheme(),
             logo_font=logo_font,
             resolution=resolution,
             **kwargs,

--- a/seqlike/SeqLikeAccessor.py
+++ b/seqlike/SeqLikeAccessor.py
@@ -3,7 +3,9 @@ from typing import Optional
 import warnings
 
 import numpy as np
-import pandas as pd
+
+# import pandas as pd
+import lazy_loader as lazy
 from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.Data.IUPACData import extended_protein_values
@@ -25,6 +27,8 @@ from .alphabets import (
 from .draw_utils import draw_alignment, view_alignment, aa_chemistry_simple, nt_simple
 from .encoders import onehot_encoder_from_alphabet
 from .SeqLike import SeqLike
+
+pd = lazy.load("pandas")
 
 
 @pd.api.extensions.register_series_accessor("seq")

--- a/seqlike/SeqLikeAccessor.py
+++ b/seqlike/SeqLikeAccessor.py
@@ -117,9 +117,9 @@ class SeqLikeAccessor:
         :returns: a PIL Image object or Bokeh object.
         """
         if colorscheme is None and self._type == "NT":
-            colorscheme = nt_simple()
+            colorscheme = nt_simple
         elif colorscheme is None and self._type == "AA":
-            colorscheme = aa_chemistry_simple()
+            colorscheme = aa_chemistry_simple
 
         if use_bokeh:
             try:

--- a/seqlike/alignment_commands.py
+++ b/seqlike/alignment_commands.py
@@ -1,9 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+# from __future__ import absolute_import, division, print_function, unicode_literals
 from typing import List
 
 import tempfile
 from io import StringIO
-import pandas as pd
+import lazy_loader as lazy
+
 
 from Bio import AlignIO, SeqIO, Phylo
 from Bio.Align import MultipleSeqAlignment
@@ -11,6 +12,8 @@ from Bio.Align.Applications import ClustalOmegaCommandline
 
 from .AlignCommandline import MafftCommandline
 from .SeqLike import SeqLikeType, SeqLike
+
+pd = lazy.load("pandas")
 
 
 def pad_seq_records_for_alignment(seqs: List[SeqLikeType]):

--- a/seqlike/codon_tables.py
+++ b/seqlike/codon_tables.py
@@ -5,7 +5,7 @@ python_codon_tables below for reference.
 
 from copy import deepcopy
 import numpy as np
-from seqlike import SeqLike
+from seqlike.SeqLike import SeqLike
 from typing import Callable
 from python_codon_tables import get_codons_table
 

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -105,9 +105,9 @@ def convert_weblogo_color(color: "wl.color.Color", color_format: str) -> Union[t
         return hex_str
 
 
-def convert_colorscheme_to_color_map(color_scheme: "wl.colorscheme.ColorScheme", color_format: str) -> dict:
+def convert_colorscheme_to_color_map(color_scheme: Callable, color_format: str) -> dict:
     """Convert weblogo ColorScheme into bokeh color map
-    :param color_scheme: a weblogo ColorScheme object
+    :param color_scheme: a Callable that returns a weblogo ColorScheme object
     :param color_format: 'hex' or 'rgb' for hex string or RGB tuple, respectively
     :returns: a dict of bokeh colors indexed by letter
     """
@@ -115,7 +115,7 @@ def convert_colorscheme_to_color_map(color_scheme: "wl.colorscheme.ColorScheme",
 
     # convert SymbolColor to bokeh color object
     color_dict = dict()
-    for rule in color_scheme.rules:
+    for rule in color_scheme().rules:
         color_dict[rule.symbols] = convert_weblogo_color(rule.color, color_format)
     # default for spaces (white)
     color_dict["-*"] = convert_weblogo_color(wl.color.Color.from_string("white"), color_format)

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -1,29 +1,32 @@
 import sys
 import os
 import numpy as np
-from typing import Union
+from typing import Callable, Union
 
 from PIL import Image, ImageDraw, ImageFont
 
-# import weblogo as wl
 import lazy_loader as lazy
 
 wl = lazy.load("weblogo")
 
+# try:
+# import bokeh as bk
+bk = lazy.load("bokeh")
+# from bokeh.plotting import figure, show
+# from bokeh.core.properties import value
+
+# for visualization in jupyter notebook
+# from bokeh.io import output_notebook
 try:
-    import bokeh as bk
-    from bokeh.plotting import figure, show
-    from bokeh.core.properties import value
-
-    # for visualization in jupyter notebook
-    from bokeh.io import output_notebook
-
-    output_notebook()
-except ImportError:
-    print(
-        "Warning: cannot import Bokeh, so the interactive alignment viewer is disabled.",
-        file=sys.stderr,
-    )
+    get_ipython
+    bk.io.output_notebook()
+except NameError:
+    pass
+# except ImportError:
+#     print(
+#         "Warning: cannot import Bokeh, so the interactive alignment viewer is disabled.",
+#         file=sys.stderr,
+#     )
 
 from .alphabets import gap_letter
 
@@ -79,7 +82,7 @@ def nt_simple():
     )
 
 
-def convert_weblogo_color(color: wl.color.Color, color_format: str) -> Union[tuple, str]:
+def convert_weblogo_color(color: "wl.color.Color", color_format: str) -> Union[tuple, str]:
     """Convert weblogo Color to Bokeh color object
 
     Note: Weblogo colors are RGB but fractional [0, 1],
@@ -102,7 +105,7 @@ def convert_weblogo_color(color: wl.color.Color, color_format: str) -> Union[tup
         return hex_str
 
 
-def convert_colorscheme_to_color_map(color_scheme: wl.colorscheme.ColorScheme, color_format: str) -> dict:
+def convert_colorscheme_to_color_map(color_scheme: "wl.colorscheme.ColorScheme", color_format: str) -> dict:
     """Convert weblogo ColorScheme into bokeh color map
     :param color_scheme: a weblogo ColorScheme object
     :param color_format: 'hex' or 'rgb' for hex string or RGB tuple, respectively
@@ -171,7 +174,7 @@ def find_font(size, fontpath=None):
 
 def draw_alignment(
     aligned,
-    colorscheme=aa_chemistry_simple(),
+    colorscheme: Callable = aa_chemistry_simple,
     boxwidth=2,
     boxheight=12,
     label_width=100,
@@ -182,7 +185,7 @@ def draw_alignment(
 ):
     """Generate a colored figure from an alignment
     :param aligned: MultipleSeqAlignment object
-    :param colorscheme: a weblogo ColorScheme object
+    :param colorscheme: a Callable that returns a weblogo ColorScheme object
     :param boxwidth: column width of alignment
     :param boxheight: row height of alignment
     :param label_width: maximum length of row label; if None, extend to maximum label length
@@ -249,7 +252,7 @@ def view_alignment(
     aligned,
     fontsize="9pt",
     show_N=100,
-    colorscheme=aa_chemistry_simple(),
+    colorscheme: Callable = aa_chemistry_simple,
     boxwidth=9,
     boxheight=15,
     label_width=None,
@@ -264,7 +267,7 @@ def view_alignment(
     :param aligned: MultipleSeqAlignment object
     :param fontsize: font size for text labels
     :param show_N: size of sequence window (in number of sequence letters)
-    :param colorscheme: a weblogo ColorScheme object
+    :param colorscheme: a Callable that returns a weblogo ColorScheme object
     :param boxwidth: column width of alignment
     :param boxheight: row height of alignment
     :param label_width: maximum length of row label; if None, extend to maximum label length
@@ -316,7 +319,7 @@ def view_alignment(
     if show_grouping:
         colors = get_colors_for_matching(seqs)
     else:
-        colors = get_colors(seqs, colorscheme)
+        colors = get_colors(seqs, colorscheme())
     N = len(seqs[0])
     S = len(seqs)
 
@@ -344,7 +347,7 @@ def view_alignment(
     plot_width = int(5 * label_width) + boxwidth * viewlen + 40
 
     # entire sequence view (no text, with zoom)
-    p = figure(
+    p = bk.plotting.figure(
         title=None,
         plot_width=plot_width,
         plot_height=50,
@@ -368,7 +371,7 @@ def view_alignment(
     p.grid.visible = False
 
     # sequence text view with ability to scroll along x axis
-    p1 = figure(
+    p1 = bk.plotting.figure(
         title=None,
         plot_width=plot_width,
         plot_height=plot_height,
@@ -384,7 +387,7 @@ def view_alignment(
         text="text",
         text_align="center",
         text_color="black",
-        text_font=value("monospace"),
+        text_font=bk.core.properties.value("monospace"),
         text_font_size=fontsize,
     )
     rects = bk.models.glyphs.Rect(
@@ -405,5 +408,5 @@ def view_alignment(
     p1.yaxis.major_tick_line_width = 0
 
     p = bk.layouts.gridplot([[p], [p1]], toolbar_location="below")
-    show(p)
+    bk.plotting.show(p)
     return p

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -115,7 +115,7 @@ def convert_colorscheme_to_color_map(color_scheme: Callable, color_format: str) 
 
     # convert SymbolColor to bokeh color object
     color_dict = dict()
-    for rule in color_scheme.rules:
+    for rule in color_scheme().rules:
         color_dict[rule.symbols] = convert_weblogo_color(rule.color, color_format)
     # default for spaces (white)
     color_dict["-*"] = convert_weblogo_color(wl.color.Color.from_string("white"), color_format)

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -115,7 +115,7 @@ def convert_colorscheme_to_color_map(color_scheme: Callable, color_format: str) 
 
     # convert SymbolColor to bokeh color object
     color_dict = dict()
-    for rule in color_scheme().rules:
+    for rule in color_scheme.rules:
         color_dict[rule.symbols] = convert_weblogo_color(rule.color, color_format)
     # default for spaces (white)
     color_dict["-*"] = convert_weblogo_color(wl.color.Color.from_string("white"), color_format)
@@ -276,6 +276,9 @@ def view_alignment(
         instead of using the residue colorscheme
     :returns: A Bokeh plot of the Multiple Sequence Alignment.
     """
+    from bokeh.models import ColumnDataSource, Range1d
+    from bokeh.plotting import figure
+    from bokeh.models.glyphs import Rect
 
     def get_colors(seqs, color_scheme):
         """make colors for letters in sequence
@@ -319,7 +322,7 @@ def view_alignment(
     if show_grouping:
         colors = get_colors_for_matching(seqs)
     else:
-        colors = get_colors(seqs, colorscheme())
+        colors = get_colors(seqs, colorscheme)
     N = len(seqs[0])
     S = len(seqs)
 
@@ -334,9 +337,9 @@ def view_alignment(
     # use recty for rect coords with an offset
     recty = gy + 0.5
     # now we can create the ColumnDataSource with all the arrays
-    source = bk.models.ColumnDataSource(dict(x=gx, y=gy, recty=recty, text=text, colors=colors))
+    source = ColumnDataSource(dict(x=gx, y=gy, recty=recty, text=text, colors=colors))
     plot_height = len(seqs) * boxheight + 50
-    x_range = bk.models.Range1d(0, N + 1, bounds="auto")
+    x_range = Range1d(0, N + 1, bounds="auto")
     viewlen = min(show_N, N)
     # view_range is for the close up view
     view_range = (0, viewlen)
@@ -347,7 +350,8 @@ def view_alignment(
     plot_width = int(5 * label_width) + boxwidth * viewlen + 40
 
     # entire sequence view (no text, with zoom)
-    p = bk.plotting.figure(
+
+    p = figure(
         title=None,
         plot_width=plot_width,
         plot_height=50,
@@ -357,7 +361,7 @@ def view_alignment(
         min_border=0,
         toolbar_location="below",
     )
-    rects = bk.models.glyphs.Rect(
+    rects = Rect(
         x="x",
         y="recty",
         width=1,
@@ -371,7 +375,7 @@ def view_alignment(
     p.grid.visible = False
 
     # sequence text view with ability to scroll along x axis
-    p1 = bk.plotting.figure(
+    p1 = figure(
         title=None,
         plot_width=plot_width,
         plot_height=plot_height,
@@ -390,7 +394,7 @@ def view_alignment(
         text_font=bk.core.properties.value("monospace"),
         text_font_size=fontsize,
     )
-    rects = bk.models.glyphs.Rect(
+    rects = Rect(
         x="x",
         y="recty",
         width=1,

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -4,9 +4,11 @@ import numpy as np
 from typing import Union
 
 from PIL import Image, ImageDraw, ImageFont
-from weblogo import colorscheme
-from weblogo.color import Color
-from weblogo.seq import protein_alphabet
+
+# import weblogo as wl
+import lazy_loader as lazy
+
+wl = lazy.load("weblogo")
 
 try:
     import bokeh as bk
@@ -27,50 +29,57 @@ from .alphabets import gap_letter
 
 
 # revised from chemistry_extended: removed neutral and moved N and Q to polar
-aa_chemistry_simple = colorscheme.ColorScheme(
-    [
-        colorscheme.SymbolColor("GSTYCNQ", "green", "polar"),
-        colorscheme.SymbolColor("KRH", "blue", "basic"),
-        colorscheme.SymbolColor("DE", "red", "acidic"),
-        colorscheme.SymbolColor("PAWFLIMV", "black", "hydrophobic"),
-        colorscheme.SymbolColor("X", "gray", "unknown"),
-    ],
-    alphabet=protein_alphabet,
-)
+def aa_chemistry_simple():
+    return wl.colorscheme.ColorScheme(
+        [
+            wl.colorscheme.SymbolColor("GSTYCNQ", "green", "polar"),
+            wl.colorscheme.SymbolColor("KRH", "blue", "basic"),
+            wl.colorscheme.SymbolColor("DE", "red", "acidic"),
+            wl.colorscheme.SymbolColor("PAWFLIMV", "black", "hydrophobic"),
+            wl.colorscheme.SymbolColor("X", "gray", "unknown"),
+        ],
+        alphabet=wl.seq.protein_alphabet,
+    )
+
 
 # from makelogo
-aa_chemistry_extended = colorscheme.ColorScheme(
-    [
-        colorscheme.SymbolColor("GSTYC", "green", "polar"),
-        colorscheme.SymbolColor("NQ", "purple", "neutral"),
-        colorscheme.SymbolColor("KRH", "blue", "basic"),
-        colorscheme.SymbolColor("DE", "red", "acidic"),
-        colorscheme.SymbolColor("PAWFLIMV", "black", "hydrophobic"),
-        colorscheme.SymbolColor("X", "gray", "unknown"),
-    ],
-    alphabet=protein_alphabet,
-)
-
-aa_dssp_color = colorscheme.ColorScheme(
-    [
-        colorscheme.SymbolColor("EB", "red", "strand"),
-        colorscheme.SymbolColor("HGI", "blue", "helix"),
-        colorscheme.SymbolColor("TSC-", "light gray", "coil"),
-    ],
-    alphabet=protein_alphabet,
-)
-
-nt_simple = colorscheme.ColorScheme(
-    [
-        colorscheme.SymbolColor("G", "orange"),
-        colorscheme.SymbolColor("TU", "red"),
-        colorscheme.SymbolColor("C", "blue"),
-        colorscheme.SymbolColor("A", "green"),
-    ],
-)
+def aa_chemistry_extended():
+    return wl.colorscheme.ColorScheme(
+        [
+            wl.colorscheme.SymbolColor("GSTYC", "green", "polar"),
+            wl.colorscheme.SymbolColor("NQ", "purple", "neutral"),
+            wl.colorscheme.SymbolColor("KRH", "blue", "basic"),
+            wl.colorscheme.SymbolColor("DE", "red", "acidic"),
+            wl.colorscheme.SymbolColor("PAWFLIMV", "black", "hydrophobic"),
+            wl.colorscheme.SymbolColor("X", "gray", "unknown"),
+        ],
+        alphabet=wl.seq.protein_alphabet,
+    )
 
 
-def convert_weblogo_color(color: Color, color_format: str) -> Union[tuple, str]:
+def aa_dssp_color():
+    return wl.colorscheme.ColorScheme(
+        [
+            wl.colorscheme.SymbolColor("EB", "red", "strand"),
+            wl.colorscheme.SymbolColor("HGI", "blue", "helix"),
+            wl.colorscheme.SymbolColor("TSC-", "light gray", "coil"),
+        ],
+        alphabet=wl.seq.protein_alphabet,
+    )
+
+
+def nt_simple():
+    return wl.colorscheme.ColorScheme(
+        [
+            wl.colorscheme.SymbolColor("G", "orange"),
+            wl.colorscheme.SymbolColor("TU", "red"),
+            wl.colorscheme.SymbolColor("C", "blue"),
+            wl.colorscheme.SymbolColor("A", "green"),
+        ],
+    )
+
+
+def convert_weblogo_color(color: wl.color.Color, color_format: str) -> Union[tuple, str]:
     """Convert weblogo Color to Bokeh color object
 
     Note: Weblogo colors are RGB but fractional [0, 1],
@@ -93,7 +102,7 @@ def convert_weblogo_color(color: Color, color_format: str) -> Union[tuple, str]:
         return hex_str
 
 
-def convert_colorscheme_to_color_map(color_scheme: colorscheme.ColorScheme, color_format: str) -> dict:
+def convert_colorscheme_to_color_map(color_scheme: wl.colorscheme.ColorScheme, color_format: str) -> dict:
     """Convert weblogo ColorScheme into bokeh color map
     :param color_scheme: a weblogo ColorScheme object
     :param color_format: 'hex' or 'rgb' for hex string or RGB tuple, respectively
@@ -106,7 +115,7 @@ def convert_colorscheme_to_color_map(color_scheme: colorscheme.ColorScheme, colo
     for rule in color_scheme.rules:
         color_dict[rule.symbols] = convert_weblogo_color(rule.color, color_format)
     # default for spaces (white)
-    color_dict["-*"] = convert_weblogo_color(Color.from_string("white"), color_format)
+    color_dict["-*"] = convert_weblogo_color(wl.color.Color.from_string("white"), color_format)
     # expand letter strings so that dict maps to single letters
     expanded_color_dict = dict()
     for letters, color in color_dict.items():
@@ -123,16 +132,16 @@ def apply_matching_colorscheme(letter, ref_letter, color_format: str):
     """
     # gap match
     if letter == gap_letter and letter == ref_letter:
-        return convert_weblogo_color(Color.from_string("lightblue"), color_format)
+        return convert_weblogo_color(wl.color.Color.from_string("lightblue"), color_format)
     # gap
     elif letter == gap_letter:
-        return convert_weblogo_color(Color.from_string("white"), color_format)
+        return convert_weblogo_color(wl.color.Color.from_string("white"), color_format)
     # match
     elif letter == ref_letter:
-        return convert_weblogo_color(Color.from_string("limegreen"), color_format)
+        return convert_weblogo_color(wl.color.Color.from_string("limegreen"), color_format)
     # mismatch
     else:
-        return convert_weblogo_color(Color.from_string("darkred"), color_format)
+        return convert_weblogo_color(wl.color.Color.from_string("darkred"), color_format)
 
 
 def find_font(size, fontpath=None):
@@ -162,7 +171,7 @@ def find_font(size, fontpath=None):
 
 def draw_alignment(
     aligned,
-    colorscheme=aa_chemistry_simple,
+    colorscheme=aa_chemistry_simple(),
     boxwidth=2,
     boxheight=12,
     label_width=100,
@@ -240,7 +249,7 @@ def view_alignment(
     aligned,
     fontsize="9pt",
     show_N=100,
-    colorscheme=aa_chemistry_simple,
+    colorscheme=aa_chemistry_simple(),
     boxwidth=9,
     boxheight=15,
     label_width=None,

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -16,10 +16,11 @@ bk = lazy.load("bokeh")
 # from bokeh.core.properties import value
 
 # for visualization in jupyter notebook
-# from bokeh.io import output_notebook
 try:
     get_ipython
-    bk.io.output_notebook()
+    from bokeh.io import output_notebook
+
+    output_notebook()
 except NameError:
     pass
 # except ImportError:

--- a/seqlike/encoders.py
+++ b/seqlike/encoders.py
@@ -1,4 +1,3 @@
-from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
 from .alphabets import NT, AA, STANDARD_AA, STANDARD_NT
 
 
@@ -8,6 +7,8 @@ def index_encoder_from_alphabet(alphabet):
     :param alphabet: a iterable of unique tokens
     :returns: OrdinalEncoder
     """
+    from sklearn.preprocessing import OrdinalEncoder
+
     categories = [[letter for letter in alphabet]]
     fit_list = [[letter] for letter in alphabet]
     return OrdinalEncoder(dtype=float, categories=categories).fit(fit_list)
@@ -19,30 +20,33 @@ def onehot_encoder_from_alphabet(alphabet):
     :param alphabet: a iterable of unique tokens
     :returns: OneHotEncoder
     """
+    from sklearn.preprocessing import OneHotEncoder
+
     categories = [[letter for letter in alphabet]]
     fit_list = [[letter] for letter in alphabet]
     return OneHotEncoder(dtype=float, sparse=False, categories=categories).fit(fit_list)
 
 
-ENCODERS = {
-    "NT": {
-        "index": {
-            "standard": index_encoder_from_alphabet(STANDARD_NT),
-            "full": index_encoder_from_alphabet(NT),
-        },
-        "onehot": {
-            "standard": onehot_encoder_from_alphabet(STANDARD_NT),
-            "full": onehot_encoder_from_alphabet(NT),
-        },
-    },
-    "AA": {
-        "index": {
-            "standard": index_encoder_from_alphabet(STANDARD_AA),
-            "full": index_encoder_from_alphabet(AA),
-        },
-        "onehot": {
-            "standard": onehot_encoder_from_alphabet(STANDARD_AA),
-            "full": onehot_encoder_from_alphabet(AA),
-        },
-    },
-}
+# Defer execution till when it's needed.
+# ENCODERS = {
+#     "NT": {
+#         "index": {
+#             "standard": index_encoder_from_alphabet(STANDARD_NT),
+#             "full": index_encoder_from_alphabet(NT),
+#         },
+#         "onehot": {
+#             "standard": onehot_encoder_from_alphabet(STANDARD_NT),
+#             "full": onehot_encoder_from_alphabet(NT),
+#         },
+#     },
+#     "AA": {
+#         "index": {
+#             "standard": index_encoder_from_alphabet(STANDARD_AA),
+#             "full": index_encoder_from_alphabet(AA),
+#         },
+#         "onehot": {
+#             "standard": onehot_encoder_from_alphabet(STANDARD_AA),
+#             "full": onehot_encoder_from_alphabet(AA),
+#         },
+#     },
+# }

--- a/seqlike/utils/constructor.py
+++ b/seqlike/utils/constructor.py
@@ -1,27 +1,27 @@
-"""Functions that are used in the SeqLike constructor.
+# """Functions that are used in the SeqLike constructor.
 
-They live outside of the SeqLike.py module to keep it unpolluted.
+# They live outside of the SeqLike.py module to keep it unpolluted.
 
-All of the functions here ought to be imported into its sibling __init__.py file
-so that it's available at the top of the `seqlike.utils` namespace.
-"""
-from copy import deepcopy
-from seqlike.utils.validation import validate_seq_type
-from seqlike.encoders import index_encoder_from_alphabet, onehot_encoder_from_alphabet
-from typing import Any, Union
+# All of the functions here ought to be imported into its sibling __init__.py file
+# so that it's available at the top of the `seqlike.utils` namespace.
+# """
+# from copy import deepcopy
+# from seqlike.utils.validation import validate_seq_type
+# from seqlike.encoders import index_encoder_from_alphabet, onehot_encoder_from_alphabet
+# from typing import Any, Union
 
-import numpy as np
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from multipledispatch import dispatch
-from seqlike.alphabets import (
-    AA,
-    NT,
-    STANDARD_AA,
-    STANDARD_NT,
-    is_AA,
-    is_NT,
-    is_STANDARD_AA,
-    is_STANDARD_NT,
-)
-from seqlike.utils.sequences import add_seqnums_to_letter_annotations
+# # import numpy as np
+# from Bio.Seq import Seq
+# from Bio.SeqRecord import SeqRecord
+# from multipledispatch import dispatch
+# from seqlike.alphabets import (
+#     AA,
+#     NT,
+#     STANDARD_AA,
+#     STANDARD_NT,
+#     is_AA,
+#     is_NT,
+#     is_STANDARD_AA,
+#     is_STANDARD_NT,
+# )
+# from seqlike.utils.sequences import add_seqnums_to_letter_annotations

--- a/tests/test_SeqLike.py
+++ b/tests/test_SeqLike.py
@@ -1,26 +1,17 @@
-import os
-import sys
-from copy import deepcopy
 import tempfile
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from copy import deepcopy
 
 import numpy as np
 import pytest
-
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from seqlike import SeqLike
-
-from seqlike.codon_tables import yeast_codon_table, ecoli_codon_table, codon_table_to_codon_map
-from seqlike.SeqLike import NT, AA, STANDARD_NT, STANDARD_AA
+from hypothesis import given
+from hypothesis.strategies import composite, integers, sampled_from, text
+from seqlike.codon_tables import codon_table_to_codon_map, ecoli_codon_table, yeast_codon_table
+from seqlike.SeqLike import AA, NT, STANDARD_AA, STANDARD_NT, SeqLike
 
 from . import test_path
-
-
-from hypothesis import given, assume
-from hypothesis.strategies import composite, text, integers, sampled_from
 
 
 ALPHABETS = [NT, AA, STANDARD_NT, STANDARD_AA]
@@ -112,8 +103,15 @@ def test_SeqLike_interconversion():
     based on target types.
     """
     seqstr = "TCGCACACTGCA"
-    seq0 = SeqLike(seqstr, "nt", id="id", name="name", description="description",
-                   annotations={"molecule_type": "DNA"}, dbxrefs=["/accessions=['Z78439']"])
+    seq0 = SeqLike(
+        seqstr,
+        "nt",
+        id="id",
+        name="name",
+        description="description",
+        annotations={"molecule_type": "DNA"},
+        dbxrefs=["/accessions=['Z78439']"],
+    )
 
     seq1 = SeqLike(seq0, "dna").nt()
     seq2 = SeqLike(seq0, "dna").aa()

--- a/tests/test_SeqLikeAccessor.py
+++ b/tests/test_SeqLikeAccessor.py
@@ -1,21 +1,16 @@
 from copy import deepcopy
-import os
-import sys
 import tempfile
 
-# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import numpy as np
 import pandas as pd
 import pytest
-import pathlib
 from PIL import Image
 
 from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from seqlike import SeqLike
 from seqlike.codon_tables import human_codon_table, human_codon_map, codon_table_to_codon_map
-from seqlike.alphabets import gap_letter
 
 from . import test_path
 

--- a/tests/test_SeqLikeAccessor.py
+++ b/tests/test_SeqLikeAccessor.py
@@ -3,7 +3,7 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import numpy as np
 import pandas as pd

--- a/tests/test_SeqLike_alignment.py
+++ b/tests/test_SeqLike_alignment.py
@@ -1,6 +1,4 @@
 from types import *
-import os
-import pytest
 import pandas as pd
 from seqlike import SeqLike
 from seqlike.alignment_utils import align

--- a/tests/test_SeqLike_alignment.py
+++ b/tests/test_SeqLike_alignment.py
@@ -3,6 +3,7 @@ import pandas as pd
 from seqlike import SeqLike
 from seqlike.alignment_utils import align
 from seqlike.alignment_commands import mafft_alignment, pad_seq_records_for_alignment
+import pytest
 
 
 def get_aa_seqrecs():
@@ -58,7 +59,7 @@ def get_nt_seqrecs():
     return seqrecs
 
 
-@pytest.mark.xfail("May fail if MAFFT is not installed.")
+@pytest.mark.xfail(reason="May fail if MAFFT is not installed.")
 def test_alignment_commands():
     seqrecs = get_aa_seqrecs()
     ## test mafft

--- a/tests/test_SeqLike_alignment.py
+++ b/tests/test_SeqLike_alignment.py
@@ -58,13 +58,14 @@ def get_nt_seqrecs():
     return seqrecs
 
 
+@pytest.mark.xfail("May fail if MAFFT is not installed.")
 def test_alignment_commands():
     seqrecs = get_aa_seqrecs()
     ## test mafft
     aligned = mafft_alignment(seqrecs)
-    print("\nmafft_alignment:", aligned)
+    # print("\nmafft_alignment:", aligned)
     aligned = mafft_alignment(seqrecs, dash=True)
-    print("\nmafft_alignment (MAFFT-DASH):", aligned)
+    # print("\nmafft_alignment (MAFFT-DASH):", aligned)
 
 
 def test_pad_seq_records_for_alignment():

--- a/tests/test_draw_utils.py
+++ b/tests/test_draw_utils.py
@@ -29,7 +29,7 @@ def test_convert_weblogo_color():
 
 def test_convert_colorscheme_to_color_map():
     # RGB
-    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple(), color_format="rgb")
+    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple, color_format="rgb")
     for letter in "GSTYCNQ":
         assert color_dict[letter] == (0, 128, 0)
     for letter in "KRH":
@@ -42,7 +42,7 @@ def test_convert_colorscheme_to_color_map():
         for letter in rule.symbols:
             color_dict[letter] == convert_weblogo_color(rule.color, "rgb")
     # hex
-    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple(), color_format="hex")
+    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple, color_format="hex")
     for rule in aa_chemistry_simple().rules:
         for letter in rule.symbols:
             color_dict[letter] == convert_weblogo_color(rule.color, color_format="hex")
@@ -81,6 +81,7 @@ def test_view_alignment():
     fig = view_alignment(MultipleSeqAlignment(aligned))
 
 
+@pytest.mark.xfail(reason="Will fail is Ghostscript is not on path.")
 def test_draw_weblogo():
     aligned = get_aligned_aa_seqrecs_duplicate_ids()
     df = pd.DataFrame({"seqs": [SeqLike(seq, seq_type="aa") for seq in aligned]})

--- a/tests/test_draw_utils.py
+++ b/tests/test_draw_utils.py
@@ -5,7 +5,7 @@ from Bio.Align import MultipleSeqAlignment
 from weblogo.color import Color
 from seqlike.draw_utils import draw_alignment, view_alignment
 from seqlike.draw_utils import convert_weblogo_color, apply_matching_colorscheme
-from seqlike.draw_utils import aa_chemistry_simple, aa_dssp_color, convert_colorscheme_to_color_map
+from seqlike.draw_utils import aa_chemistry_simple, convert_colorscheme_to_color_map
 from seqlike.SeqLike import SeqLike
 from .test_SeqLike_alignment import get_aligned_aa_seqrecs_duplicate_ids
 
@@ -29,7 +29,7 @@ def test_convert_weblogo_color():
 
 def test_convert_colorscheme_to_color_map():
     # RGB
-    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple, color_format="rgb")
+    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple(), color_format="rgb")
     for letter in "GSTYCNQ":
         assert color_dict[letter] == (0, 128, 0)
     for letter in "KRH":
@@ -38,12 +38,12 @@ def test_convert_colorscheme_to_color_map():
         assert color_dict[letter] == (255, 0, 0)
     for letter in "PAWFLIMV":
         assert color_dict[letter] == (0, 0, 0)
-    for rule in aa_chemistry_simple.rules:
+    for rule in aa_chemistry_simple().rules:
         for letter in rule.symbols:
             color_dict[letter] == convert_weblogo_color(rule.color, "rgb")
     # hex
-    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple, color_format="hex")
-    for rule in aa_chemistry_simple.rules:
+    color_dict = convert_colorscheme_to_color_map(aa_chemistry_simple(), color_format="hex")
+    for rule in aa_chemistry_simple().rules:
         for letter in rule.symbols:
             color_dict[letter] == convert_weblogo_color(rule.color, color_format="hex")
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,29 +1,23 @@
 import sklearn
 import numpy as np
-import os
-import pytest
-import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from seqlike import SeqLike
 from seqlike.encoders import index_encoder_from_alphabet, onehot_encoder_from_alphabet
-from seqlike.encoders import STANDARD_AA, STANDARD_NT, AA, NT, ENCODERS
 
 
-def test_ENCODERS():
-    for k, v in ENCODERS.items():
-        assert k in ["AA", "NT"]
-        assert isinstance(v, dict)
+# def test_ENCODERS():
+#     for k, v in ENCODERS.items():
+#         assert k in ["AA", "NT"]
+#         assert isinstance(v, dict)
 
-    for seq_type in ["AA", "NT"]:
-        for k, v in ENCODERS[seq_type].items():
-            assert k in ["onehot", "index"]
-            assert isinstance(v, dict)
+#     for seq_type in ["AA", "NT"]:
+#         for k, v in ENCODERS[seq_type].items():
+#             assert k in ["onehot", "index"]
+#             assert isinstance(v, dict)
 
-            for kk, vv in v.items():
-                assert kk in ["full", "standard"]
-                assert isinstance(vv, sklearn.preprocessing._encoders._BaseEncoder)
+#             for kk, vv in v.items():
+#                 assert kk in ["full", "standard"]
+#                 assert isinstance(vv, sklearn.preprocessing._encoders._BaseEncoder)
 
 
 def test_index_encoder():


### PR DESCRIPTION
I have used a few tricks to improve the import time of SeqLike.

1. Deferred execution of weblogo stuff by encapsulation inside a function rather than as raw variables.
3. Lazy loading of modules where the top-level package is used.
4. Imports within functions/class methods where the top-level package is not used (e.g. Bokeh stuff) to avoid dependency import overhead.

In doing this, I have already verified that the tests all pass and the tutorial notebook runs.

This PR resolves #52.

Import times have been reduced from 2s to 0.4 seconds, ~5x. This will dramatically improve UX and DevX when building out low-latency tools that rely on SeqLike.