### PR TITLE
add commandline wrapper function for Muscle 3.8 #24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add alignment wrapper for Muscle by @ndousis.
+
 ## [v1.3.0] - 2022-05-17
 
 ## [v1.2.0] - 2022-04-12

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - bokeh
   - ghostscript
   - python-codon-tables
-  - mkdocstrings
   - pyprojroot
   # Code quality
   - pre-commit
@@ -34,6 +33,7 @@ dependencies:
   - mkdocs
   - mkdocs-material=8.1.3
   - mkdocstrings
+  - mkdocstrings-python
   # Infrastructural
   - bump2version
   # Dependencies of mknotebooks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ plugins:
       handlers:
         python:
           selection:
-            docstring_style: restructured-text
+            docstring_style: sphinx
 
   - mknotebooks:
       execute: true
@@ -36,7 +36,7 @@ plugins:
 
 # Taken from here: https://squidfunk.github.io/mkdocs-material/extensions/codehilite/
 markdown_extensions:
-#   - codehilite
+  #   - codehilite
   - admonition
 #   - pymdownx.tabbed
 #   - pymdownx.arithmatex
@@ -48,7 +48,7 @@ markdown_extensions:
 #   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 extra_css:
-#   - css/nb_mods.css
+  #   - css/nb_mods.css
   - css/apidocs.css
 
 # TODO: Uncomment and set values to correct ones as appropriate.

--- a/seqlike/alignment_commands.py
+++ b/seqlike/alignment_commands.py
@@ -105,6 +105,15 @@ def mafft_alignment(seqrecs, preserve_order=True, **kwargs):
 def muscle_alignment(seqrecs, preserve_order=True, **kwargs):
     """Align sequences using Muscle 3.8.
 
+    Notes:
+
+    1. Muscle's latest version is version 5.1. However, the interface is different from version 3.8
+       BioPython's MuscleCommandline is only compatible with version 3.8.
+       See this comment for more information: https://github.com/modernatx/seqlike/pull/60#issue-1257542946
+    2. The preserve_order parameter (preserves original sequence order,
+       as aligner may try to group sequences by similarity) may still be buggy.
+       Also see this comment for more information: https://github.com/modernatx/seqlike/pull/60#issue-1257542946
+
     :param seqrecs: a list or dict of SeqRecord that will be aligned to ref
     :param preserve_order: if True, reorder aligned seqrecs to match input order.
     :param **kwargs: additional arguments for alignment command

--- a/seqlike/alignment_commands.py
+++ b/seqlike/alignment_commands.py
@@ -10,7 +10,7 @@ from Bio import AlignIO, SeqIO, Phylo
 from Bio.Align import MultipleSeqAlignment
 from Bio.Align.Applications import ClustalOmegaCommandline
 
-from .AlignCommandline import MafftCommandline
+from .AlignCommandline import MafftCommandline, MuscleCommandline
 from .SeqLike import SeqLikeType, SeqLike
 
 pd = lazy.load("pandas")
@@ -99,6 +99,25 @@ def mafft_alignment(seqrecs, preserve_order=True, **kwargs):
     # MAFFT does not reorder alignment by default (reorder=False), but don't overwrite 'reorder' if set
     if "reorder" not in kwargs:
         kwargs["reorder"] = not preserve_order
+    return _generic_alignment(commandline, seqrecs, preserve_order=preserve_order, **kwargs)
+
+
+def muscle_alignment(seqrecs, preserve_order=True, **kwargs):
+    """Align sequences using Muscle 3.8.
+
+    :param seqrecs: a list or dict of SeqRecord that will be aligned to ref
+    :param preserve_order: if True, reorder aligned seqrecs to match input order.
+    :param **kwargs: additional arguments for alignment command
+    :returns: a MultipleSeqAlignment object with aligned sequences
+    """
+
+    def commandline(file_obj, **kwargs):
+        cline = MuscleCommandline(input=file_obj.name, **kwargs)
+        return _generic_aligner_commandline_stdout(cline)
+
+    # Muscle reorders alignment by default, but don't overwrite 'group' if already set
+    if "group" not in kwargs:
+        kwargs["group"] = not preserve_order
     return _generic_alignment(commandline, seqrecs, preserve_order=preserve_order, **kwargs)
 
 

--- a/tests/test_SeqLike_alignment.py
+++ b/tests/test_SeqLike_alignment.py
@@ -2,7 +2,7 @@ from types import *
 import pandas as pd
 from seqlike import SeqLike
 from seqlike.alignment_utils import align
-from seqlike.alignment_commands import mafft_alignment, pad_seq_records_for_alignment
+from seqlike.alignment_commands import mafft_alignment, muscle_alignment, pad_seq_records_for_alignment
 import pytest
 
 
@@ -60,13 +60,22 @@ def get_nt_seqrecs():
 
 
 @pytest.mark.xfail(reason="May fail if MAFFT is not installed.")
-def test_alignment_commands():
+def test_mafft_alignment():
     seqrecs = get_aa_seqrecs()
-    ## test mafft
-    aligned = mafft_alignment(seqrecs)
-    # print("\nmafft_alignment:", aligned)
-    aligned = mafft_alignment(seqrecs, dash=True)
-    # print("\nmafft_alignment (MAFFT-DASH):", aligned)
+    # test mafft (but not really testing anything except that the command works...)
+    aligned1 = mafft_alignment(seqrecs)
+    aligned2 = mafft_alignment(seqrecs, dash=True)
+
+
+@pytest.mark.xfail(reason="May fail if Muscle is not installed.")
+def test_muscle_alignment():
+    seqrecs = get_aa_seqrecs()
+    # test muscle
+    aligned1 = muscle_alignment(seqrecs)
+    aligned2 = muscle_alignment(seqrecs, group=False)
+    assert seqrecs[1].id == aligned2[1].id
+    assert seqrecs[1].seq != aligned2[1].seq
+    assert aligned1 != aligned2
 
 
 def test_pad_seq_records_for_alignment():


### PR DESCRIPTION
The wrapper function `muscle_alignment` permits alignment using Muscle 3.8:
```python
from seqlike.alignment_commands import muscle_alignment

sequences.seq.align(aligner=muscle_alignment, muscle_arg1=something, muscle_arg2=something)
```
and addresses #24.  All tests pass except `tests/test_assets.py::test_free_mono_font_exists`.  Two notes:
1. the latest version of Muscle is v5.1 and has a different interface than v3.8; `MuscleCommandline` is compatible with v3.8.
2. the `preserve_order` parameter (preserves original sequence order, as aligner may try to group sequences by similarity) may still be buggy.