### PR TITLE
Add missing setup.py deps, add notebook extras, and move test deps to extras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-biopython
-numpy
-pandas
-scikit-learn
-pytest
-python-codon-tables
-weblogo
-lazy-loader

--- a/seqlike/draw_utils.py
+++ b/seqlike/draw_utils.py
@@ -23,11 +23,10 @@ try:
     output_notebook()
 except NameError:
     pass
-# except ImportError:
-#     print(
-#         "Warning: cannot import Bokeh, so the interactive alignment viewer is disabled.",
-#         file=sys.stderr,
-#     )
+except ImportError:
+    raise ValueError(
+        "Bokeh is required for the interactive alignment viewer in notebooks. Install `seqlike[notebook]`",
+    )
 
 from .alphabets import gap_letter
 

--- a/setup.py
+++ b/setup.py
@@ -111,17 +111,19 @@ def download_mafft(kind="deb") -> Path:
 README = Path("README.md").read_text()
 
 install_requires = [
+    "Pillow",
     "biopython",
+    "lazy-loader",
+    "multipledispatch",
     "numpy",
     "pandas",
+    "python-codon-tables",
     "scikit-learn",
     "weblogo",
-    "Pillow",
-    # :note: pytest should be under tests_require, but this doesn't seem to work
-    "pytest-regtest",
+]
+test_requires = [
     "pytest",
-    "multipledispatch",
-    "python-codon-tables",
+    "pytest-regtest",
 ]
 
 setup(
@@ -138,14 +140,14 @@ setup(
         "Issue Tracker": "https://github.com/modernatx/seqlike/issues",
     },
     install_requires=install_requires,
+    extra_requires={
+        "notebook": ["bokeh"], # Used in ipython/jupyter
+        "test": test_requires,
+    },
     package_data={"seqlike": ["*.ttf"]},
-    # tests_require=[
-    #    'pytest-regtest',
-    #    'pytest',
-    # ],
     classifiers=[
         "Intended Audience :: Science/Research",
-        'Operating System :: OS Independent',
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
I had a couple import errors (see below) when testing this package out that are related to undeclared dependencies in `setup.py`. Some were in `requirements.txt`, but not declared in `setup.py`'s `install_requires`, so I moved them all to `setup.py` and removed `requirements.txt` (so this doesn't happen again :crossed_fingers:).

I also added 2 extras:
- `seqlike[test]`: this has the `pytest*` deps (which I removed from the main `install_requires`)
- `seqlike[notebook]`: adds `bokeh`, which is (currently) required when using ipython/jupyter (I think there were some refactors to make bokeh a lazy import, but it is still imported eagerly/required in notebooks)

---

Here are the errors I saw:

```
.../lib/python3.7/site-packages/seqlike/SeqLike.py in <module>
      9 from typing import Callable, Optional, Union
     10
---> 11 import lazy_loader as lazy
     12
     13 from Bio.Seq import Seq

ModuleNotFoundError: No module named 'lazy_loader'
```

```
.../lib/python3.7/site-packages/seqlike/draw_utils.py in <module>
     19 try:
     20     get_ipython
---> 21     from bokeh.io import output_notebook
     22
     23     output_notebook()

ModuleNotFoundError: No module named 'bokeh'
```
