### PR TITLE
added "DNA" `molecule_type` annotation after back_translation

### DIFF
--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -214,11 +214,7 @@ class SeqLike(SequenceLike):
         if self._nt_record and self._aa_record is None and auto_translate:
             translate_kwargs = dict(id=True, name=True, description=True, annotations=True, dbxrefs=True)
             translate_kwargs.update(kwargs)
-            translated = self.translate(**translate_kwargs)
-            # neutralize "protein" `molecule_type` annotation added by BioPython's `SeqRecord.translate()`
-            # translated._aa_record.annotations.pop("molecule_type")
-            translated._aa_record.annotations["molecule_type"] = None
-            return translated
+            return self.translate(**translate_kwargs)
 
         # Return based on _type.
         if self._type == "AA":
@@ -292,6 +288,8 @@ class SeqLike(SequenceLike):
                 "As a safeguard, SeqLike objects do not allow this to happen. "
             )
         sc._aa_record = record_from(sc._nt_record.translate(gap=gap_letter, **kwargs))
+        # neutralize "protein" `molecule_type` annotation added by BioPython's `SeqRecord.translate()`
+        sc._aa_record.annotations.pop("molecule_type")
         return sc.aa()
 
     def back_translate(self, codon_map: Callable = None, **kwargs) -> "SeqLike":

--- a/seqlike/SeqLike.py
+++ b/seqlike/SeqLike.py
@@ -176,7 +176,9 @@ class SeqLike(SequenceLike):
         """
         # Start with auto-back-translation
         if self._aa_record and self._nt_record is None and auto_backtranslate:
-            return self.back_translate(**kwargs)
+            nt_record = self.back_translate(**kwargs)
+            nt_record.annotations["molecule_type"] = "DNA"
+            return nt_record
 
         if self._type == "NT":
             return deepcopy(self)
@@ -606,7 +608,7 @@ class SeqLike(SequenceLike):
                 elif self._type == "NT":
                     _nt_record = deepcopy(self._nt_record)[idx]
                     try:
-                        _aa_record = _nt_record.translate()
+                        _aa_record = _nt_record.translate(gap=gap_letter)
                     except Exception as e:
                         warnings.warn(e)
                     sliced = SeqLike(_nt_record, **seqlike_kwargs)

--- a/tests/test_SeqLike.py
+++ b/tests/test_SeqLike.py
@@ -110,7 +110,6 @@ def test_SeqLike_interconversion():
         id="id",
         name="name",
         description="description",
-        annotations={"molecule_type": "DNA"},
         dbxrefs=["/accessions=['Z78439']"],
     )
 
@@ -203,7 +202,9 @@ def assert_matched_properties(s1, s2):
     assert s1.id == s2.id
     assert s1.name == s2.name
     assert s1.description == s2.description
-    # SeqRecord automatically sets the molecule_type annotation, so just check keys
+    # SeqRecord automatically sets the molecule_type annotation, so remove it
+    # s1.annotations.pop("molecule_type", None)
+    # s2.annotations.pop("molecule_type", None)
     assert s1.annotations.keys() == s2.annotations.keys()
     assert s1.dbxrefs == s2.dbxrefs
 

--- a/tests/test_SeqLike.py
+++ b/tests/test_SeqLike.py
@@ -202,10 +202,7 @@ def assert_matched_properties(s1, s2):
     assert s1.id == s2.id
     assert s1.name == s2.name
     assert s1.description == s2.description
-    # SeqRecord automatically sets the molecule_type annotation, so remove it
-    # s1.annotations.pop("molecule_type", None)
-    # s2.annotations.pop("molecule_type", None)
-    assert s1.annotations.keys() == s2.annotations.keys()
+    assert s1.annotations == s2.annotations
     assert s1.dbxrefs == s2.dbxrefs
 
 

--- a/tests/test_SeqLike.py
+++ b/tests/test_SeqLike.py
@@ -8,7 +8,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from hypothesis import given
 from hypothesis.strategies import composite, integers, sampled_from, text
-from seqlike.codon_tables import codon_table_to_codon_map, ecoli_codon_table, yeast_codon_table
+from seqlike.codon_tables import codon_table_to_codon_map, ecoli_codon_table, yeast_codon_table, ecoli_codon_map
 from seqlike.SeqLike import AA, NT, STANDARD_AA, STANDARD_NT, SeqLike, aaSeqLike
 from seqlike.MutationSet import MutationSet
 
@@ -356,6 +356,22 @@ def test_slice(seqstr, seq_type):
     for seqnums in ["2", "3", "4", "5"], ["1", "10", "12"], ["10", "11", "12", "1"]:
         assert s.slice(seqnums).to_str() == "".join(seqstr[int(n) - 1] for n in seqnums)
         assert s.slice(seqnums).id == s.id
+
+
+@pytest.mark.parametrize(
+    "seqstr, seq_type",
+    [("TTCGACACTGCA", "nt"), ("TTC---GACACTGCA", "nt"), ("GEGDATYGKLTLKFICTT", "aa"), ("GE-DATYGKLTLKFICTT", "aa")],
+)
+def test_slice_with_back_translation(seqstr, seq_type):
+    s0 = SeqLike(seqstr, seq_type=seq_type)
+    if seq_type == "nt":
+        s = s0.aa().back_translate(codon_map=ecoli_codon_map)
+    else:
+        s = s0.back_translate(codon_map=ecoli_codon_map)
+    for i, n in [0, 3], [1, 1], [3, 3]:
+        sliced = s[i : i + n]
+        print(sliced)
+        assert str(sliced) == str(s)[i : i + n]
 
 
 def test_slice_with_insertion_codes():


### PR DESCRIPTION
Quick fix for #68, though the fault may actually lie with `codon_tables.codon_table_to_codon_map()`.  Added a related unit test that slices translated back-translated sequences.  All tests pass.