### PR TITLE
fix Biopython deprecation warning for ungap()

### DIFF
--- a/seqlike/utils/sequences.py
+++ b/seqlike/utils/sequences.py
@@ -172,7 +172,7 @@ def ungap(seqlike, gap=None):
             gap = seqlike.seq.alphabet.gap_char
         except AttributeError:
             gap = gap_letter
-    new_seq = seqlike.seq.ungap(gap)
+    new_seq = seqlike.seq.replace(gap, "")
 
     if str(new_seq) == str(seqlike.seq):
         # Unchanged, not even the alphabet - don't need to alter annotation


### PR DESCRIPTION
Biopython's `Seq.ungap()` method [was declared obsolete with v1.79](https://github.com/biopython/biopython/pull/4153).  The deprecation warning propose a simple solution:
```python
BiopythonDeprecationWarning: myseq.ungap(gap) is deprecated; please use myseq.replace(gap, "") instead
```
All tests pass.