### PR TITLE
fixes #75 by bandaging a python_codon_tables bug

### DIFF
--- a/seqlike/codon_tables.py
+++ b/seqlike/codon_tables.py
@@ -79,13 +79,13 @@ CODON_TABLE = {
 }
 
 # https://github.com/Edinburgh-Genome-Foundry/codon-usage-tables/blob/master/codon_usage_data/tables/h_sapiens_9606.csv
-human_codon_table = get_codons_table("h_sapiens_9606")
+human_codon_table = get_codons_table("h_sapiens_9606").copy()
 
 # https://github.com/Edinburgh-Genome-Foundry/codon-usage-tables/blob/master/codon_usage_data/tables/s_cerevisiae_4932.csv
-yeast_codon_table = get_codons_table("s_cerevisiae_4932")
+yeast_codon_table = get_codons_table("s_cerevisiae_4932").copy()
 
 # https://github.com/Edinburgh-Genome-Foundry/codon-usage-tables/blob/master/codon_usage_data/tables/e_coli_316407.csv
-ecoli_codon_table = get_codons_table("e_coli_316407")
+ecoli_codon_table = get_codons_table("e_coli_316407").copy()
 
 random_codon_table = {
     "*": {"TAA": 0.33, "TAG": 0.33, "TGA": 0.33},

--- a/tests/test_codon_tables.py
+++ b/tests/test_codon_tables.py
@@ -1,5 +1,6 @@
 import pytest
 
+from python_codon_tables import get_codons_table
 from seqlike import aaSeqLike
 from seqlike.codon_tables import (
     codon_table_to_codon_map,
@@ -32,3 +33,11 @@ def test_codon_table_to_codon_map(letter):
     human_codon_map = codon_table_to_codon_map(sort_codon_table_by_frequency(human_codon_table))
     codon = aaSeqLike(letter).back_translate(codon_map=human_codon_map)
     assert sorted(human_codon_table[letter].items(), key=lambda x: x[1], reverse=True)[0][0] == str(codon)
+
+
+@pytest.mark.parametrize("codon_table_name", ["h_sapiens_9606", "s_cerevisiae_4932"])
+def test_codon_table(codon_table_name):
+    assert ''.join(sorted(human_codon_table.keys())) == '*-ACDEFGHIKLMNPQRSTVWXY'
+
+    codons_table = get_codons_table(codon_table_name)
+    assert ''.join(sorted(codons_table.keys())) == '*ACDEFGHIKLMNPQRSTVWY'


### PR DESCRIPTION
Adding entries to a codon table generated by `python_codon_tables.get_codons_table()` has the insidious effect of adding these entries to codon tables generated by subsequent calls to `get_codons_table()`.  Simply adding a `copy()` operation to codon table objects fixes this bug.

All tests pass.
